### PR TITLE
Fix the decal not being destroyed properly

### DIFF
--- a/mod_info.lua
+++ b/mod_info.lua
@@ -3,6 +3,7 @@ uid = "fa-casting-cinematics-01"
 icon = "/mods/fa-casting-cinematics/icon.png"
 version = 1
 description = "A UI mod to provide casters a more natural control over the camera. Please review the configuration file to understand the hotkey layout."
+url = "https://github.com/FAForever/fa-casting-cinematics"
 author = "Jip"
 license = "MIT"
 exclusive = false

--- a/src/Actions.lua
+++ b/src/Actions.lua
@@ -129,7 +129,7 @@ AnimateScaleAtUserUnit = function(decal, userUnit, scale, duration)
     local fork = ForkThread(
     -- fade-out-like animation
         function()
-            while not IsDestroyed(decal) and current - duration < start do
+            while not IsDestroyed(decal) and not IsDestroyed(userUnit) and current - duration < start do
                 local diff = (current - start) / duration
                 local altScale = scale * (1 - diff * diff * diff * diff)
 

--- a/src/Actions.lua
+++ b/src/Actions.lua
@@ -57,6 +57,7 @@ CreateTemporaryDecal = function(position, path, scale, duration)
     ForkThread(
         function()
             while current - duration < start do
+                current = GetSystemTimeSeconds()
                 WaitFrames(1)
             end
 
@@ -146,8 +147,6 @@ AnimateScaleAtUserUnit = function(decal, userUnit, scale, duration)
                 current = GetSystemTimeSeconds()
                 WaitFrames(1)
             end
-
-            decal:Destroy()
         end
     )
 


### PR DESCRIPTION
Fixes, among others, the following error:

```
WARNING: Error running lua script: Game object has been destroyed
         stack traceback:
         	[C]: in function `GetInterpolatedPosition'
         	...faf-vault\mods\fa-casting-cinematics\src\actions.lua(136): in function <...faf-vault\mods\fa-casting-cinematics\src\actions.lua:131>
```